### PR TITLE
Update to latest Go SDK in post_init

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -10,6 +10,7 @@ service_id = ""
 
 [scripts]
   build = "tinygo build -target=wasi -gc=conservative -o bin/main.wasm ./"
+  post_init = "go get github.com/fastly/compute-sdk-go@latest"
 
 [local_server]
 [local_server.kv_stores]


### PR DESCRIPTION
This PR adds scripts.post_init to install the `latest` version of Go SDK. This ensures that a user starting their project with this starter kit will have the newest version.

The only point of worry is that this will always get `@latest`, because there doesn't seem to be a built-in way of getting the latest `@^1` release, so if one day we release a `@^2` that changes the API surface in a way this starter kit will no longer be compatible, we'd have to be very careful to update the starter kit ASAP.