### PR TITLE
Add CI to make sure the starter kit builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
         check-latest: true
     - name: Setup Fastly CLI
       uses: fastly/compute-actions/setup@v5
+    - name: Update Go SDK
+      run: go get github.com/fastly/compute-sdk-go@latest
     - name: Build and test
       uses: fastly/compute-actions/build@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+on: pull_request
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 'stable'
+        check-latest: true
+    - name: Setup Fastly CLI
+      uses: fastly/compute-actions/setup@v5
+    - name: Build and test
+      uses: fastly/compute-actions/build@v5
+      with:
+        verbose: true

--- a/fastly.toml
+++ b/fastly.toml
@@ -9,7 +9,8 @@ name = "kv-store-go-starter-kit"
 service_id = ""
 
 [scripts]
-  build = "tinygo build -target=wasi -gc=conservative -o bin/main.wasm ./"
+  env_vars = ["GOARCH=wasm", "GOOS=wasip1"]
+  build = "go build -o bin/main.wasm ."
   post_init = "go get github.com/fastly/compute-sdk-go@latest"
 
 [local_server]


### PR DESCRIPTION
This uses the same CI process as [fastly/compute-starter-kit-go-default](https://github.com/fastly/compute-starter-kit-go-default) to check that the starter kit builds with no problems on each pull request